### PR TITLE
Add initial automated tests

### DIFF
--- a/tests/test_create_input.py
+++ b/tests/test_create_input.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import collections
+from src import create_input
+
+
+def test_conv_filename_to_condition():
+    create_input.file_to_condition_map.clear()
+    pattern = r'.*_c(?P<cond>\d{2})_.*\.mp4'
+    result = create_input.conv_filename_to_condition('video_c03_clip.mp4', pattern)
+    assert result == collections.OrderedDict([('cond', '03')])
+
+
+def test_add_clips_random_shape():
+    clips = pd.Series(['a.mp4', 'b.mp4', 'c.mp4'])
+    df = pd.DataFrame()
+    create_input.add_clips_random(clips, 2, df)
+    assert df.shape == (2, 2)
+    assert set(df.columns) == {'Q0', 'Q1'}
+    # ensure all values are from the original list
+    for col in df.columns:
+        assert set(df[col]).issubset(set(clips))

--- a/tests/test_result_parser.py
+++ b/tests/test_result_parser.py
@@ -1,0 +1,8 @@
+from src import result_parser
+
+
+def test_outliers_functions_remove_extreme():
+    votes = [1]*10 + [2]*10 + [100]
+    assert 100 not in result_parser.outliers_modified_z_score(votes)
+    assert 100 not in result_parser.outliers_iqr(votes)
+    assert 100 not in result_parser.outliers_z_score(votes)


### PR DESCRIPTION
## Summary
- add pytest test suite covering create_input and result_parser utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c6241db48328b497d05abc1447e6