### PR TITLE
Add font customization option

### DIFF
--- a/docs/conf-trapping.md
+++ b/docs/conf-trapping.md
@@ -20,7 +20,9 @@
  * `include_from_source_stimuli_in_second = 2`: use first 2 seconds from the `source` clips to generate the trapping clips.
  It may lead to a clip duration that is different from the rest of clips which should be rated. 
  
- * `keep_original_duration = true`: As a result each generated clips will be as long as the corresponding original clip.
- It is the recommended setting.    
+* `keep_original_duration = true`: As a result each generated clips will be as long as the corresponding original clip.
+It is the recommended setting.
+
+If the default font `arial.ttf` is not available on your system, provide the path to a TrueType font file using the `--font` argument when running `create_trapping_clips.py`.
  
   

--- a/docs/prep_acr.md
+++ b/docs/prep_acr.md
@@ -64,7 +64,8 @@ column name `training_pvs` (see [training_clips_acr.csv](../sample_inputs/traini
     python create_trapping_clips.py ^
         --source tp_src ^
         --des tp_out ^
-        --cfg your_config_file.cfg
+        --cfg your_config_file.cfg ^
+        --font path_to_font.ttf
     ```    
     5. Trapping clips are stored in `tp_out` directory. List of clips and their correct answer can 
     be found in `tp_out\output_report.csv`.

--- a/docs/prep_avatar.md
+++ b/docs/prep_avatar.md
@@ -57,6 +57,7 @@ For details about the different test methods for Photorealistic Avatars, please 
           --source tp_src ^
           --des tp_out ^
           --cfg your_config_file.cfg ^
+          --font path_to_font.ttf ^
           --avatar
       ```
    4. Trapping clips will be stored in the `tp_out` directory. The list of clips and their correct answers can be found in `tp_out\trapping_output_report.csv`.

--- a/docs/prep_dcr.md
+++ b/docs/prep_dcr.md
@@ -60,7 +60,8 @@ column named `training_pvs` and URLs to corresponding reference clips in column 
     python create_trapping_clips.py ^
         --source tp_src ^
         --des tp_out ^
-        --cfg your_config_file.cfg
+        --cfg your_config_file.cfg ^
+        --font path_to_font.ttf
     ```    
     5. Trapping clips are stored in `tp_out` directory. List of clips and their correct answer can 
     be found in `tp_out\output_report.csv`.

--- a/src/create_split_screen_dcr.py
+++ b/src/create_split_screen_dcr.py
@@ -14,6 +14,18 @@ import cv2
 from PIL import Image, ImageFont, ImageDraw
 from moviepy.editor import *
 
+DEFAULT_FONT = "arial.ttf"
+font_file = DEFAULT_FONT
+
+def load_font(size):
+    try:
+        return ImageFont.truetype(font_file, size)
+    except OSError:
+        try:
+            return ImageFont.truetype("DejaVuSans-Bold.ttf", size)
+        except OSError:
+            return ImageFont.load_default()
+
 video_extension = '.mp4'
 trapping_videos = []
 tmp_files = []
@@ -40,14 +52,14 @@ def create_image(width, height, clip_id, des_folder):
             font_size += 5
         else:
             font_size -= 1
-        font = ImageFont.truetype("arial.ttf", font_size)
+        font = load_font(font_size)
         text_width = font.getsize(msg)[0]
         percentage = text_width / expected_text_width
 
     # create the image
     img = Image.new('RGB', (width, height), color=(127, 127, 127))
     d = ImageDraw.Draw(img)
-    font = ImageFont.truetype("arial.ttf", font_size)
+    font = load_font(font_size)
 
     text_width = font.getsize(msg)[0]
     text_height = font.getsize(msg)[1]
@@ -158,8 +170,11 @@ if __name__ == '__main__':
 
     parser.add_argument("--source", help="source directory containing all video clips", required=True)
     parser.add_argument("--des", help="destination directory where the screens to be stored", required=True)
+    parser.add_argument("--font", help="path to a TrueType font file", default=DEFAULT_FONT)
 
     args = parser.parse_args()
+
+    font_file = args.font
 
     assert os.path.exists(args.source), f"Invalid source directory {args.source}]"
 

--- a/src/trapping_clips/create_trapping_clips.py
+++ b/src/trapping_clips/create_trapping_clips.py
@@ -18,6 +18,19 @@ import base64
 import os
 import uuid
 
+DEFAULT_FONT = "arial.ttf"
+font_file = DEFAULT_FONT
+
+def load_font(size):
+    """Load the configured font, falling back to a default if not found."""
+    try:
+        return ImageFont.truetype(font_file, size)
+    except OSError:
+        try:
+            return ImageFont.truetype("DejaVuSans-Bold.ttf", size)
+        except OSError:
+            return ImageFont.load_default()
+
 video_extension = '.mp4'
 trapping_videos = []
 tmp_files = []
@@ -79,7 +92,7 @@ def create_msg_img(cfg, score, des, v_width, v_height):
 
     score_text = str(score)
     if args.avatar and 'avatar_rating_answers' in cfg:
-        score_text = {json.loads(cfg['avatar_rating_answers'])[str(score)]
+        score_text = json.loads(cfg['avatar_rating_answers'])[str(score)]
 
     if len(cfg['message_line1'].format(score_text)) > len(cfg['message_line2'].format(score_text)):
         text = cfg['message_line1'].format(score_text)
@@ -90,14 +103,14 @@ def create_msg_img(cfg, score, des, v_width, v_height):
             font_size += 5
         else:
             font_size -= 1
-        font = ImageFont.truetype("arial.ttf", font_size)
+        font = load_font(font_size)
         text_width = font.getbbox(text)[2]
         percentage = text_width / expected_text_width
 
     # create the image
     img = Image.new('RGB', (v_width, v_height), color=(127, 127, 127))
     d = ImageDraw.Draw(img)
-    font = ImageFont.truetype("arial.ttf", font_size)
+    font = load_font(font_size)
 
     text = title
     text_bbox = font.getbbox(text)
@@ -207,7 +220,10 @@ if __name__ == '__main__':
                         help="Check trapping.cfg for all the details", required=True)
     # is avatar
     parser.add_argument("--avatar", help="Is avatar", action='store_true', default=False)
+    parser.add_argument("--font", help="path to a TrueType font file to use for the messages", default=DEFAULT_FONT)
+
     args = parser.parse_args()
+    font_file = args.font
 
     cfgpath = args.cfg
     assert os.path.exists(cfgpath), f"No configuration file in {cfgpath}]"


### PR DESCRIPTION
## Summary
- allow specifying font path for trapping clip creation and split screen generation
- fall back to DejaVuSans or the default PIL font when the specified font is missing
- document new `--font` option in trapping clip docs

## Testing
- `python -m py_compile src/trapping_clips/create_trapping_clips.py src/create_split_screen_dcr.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840d4f2ba948328b85b156579fe7164