### PR TITLE
Add loading percentage

### DIFF
--- a/src/template/ACRHR_template.html
+++ b/src/template/ACRHR_template.html
@@ -167,6 +167,7 @@ var generalErrorLog= "";
 
 // if performing of this assignment is already counted
 var hitCounterIncreased = false;
+var total_videos_count = 0;
 
 //--------------- Utilities -----------------
 
@@ -856,16 +857,22 @@ function hardware_test(){
 		return;
 	}
 	if (!startScreenRefreshRateMeasures){
-		if (videos_not_loaded_yet_set.size == 0){
+                if (videos_not_loaded_yet_set.size == 0){
+                        $("#loading_percent").html("100%");
 
-			getScreenRefreshRate(function(fps){check_screen_refresh_rate(fps);});
-			startScreenRefreshRateMeasures = true;
+                        getScreenRefreshRate(function(fps){check_screen_refresh_rate(fps);});
+                        startScreenRefreshRateMeasures = true;
 
 		}else{
 
-			$("#remaining_videos").html(videos_not_loaded_yet_set.size);
-			window.setTimeout(hardware_test, 200);
-			return;
+                        $("#remaining_videos").html(videos_not_loaded_yet_set.size);
+                        if(total_videos_count > 0){
+                                let loaded = total_videos_count - videos_not_loaded_yet_set.size;
+                                let percent = Math.round(100 * loaded / total_videos_count);
+                                $("#loading_percent").html(percent + "%");
+                        }
+                        window.setTimeout(hardware_test, 200);
+                        return;
 		}
 	}
 	if(refresh_rate_passed === null) {
@@ -2030,6 +2037,7 @@ $(function() {
         recordError("on loading video clips",e.target.src, true);
         //$("#error_loading_files").show();
     });
+    total_videos_count = videos_not_loaded_yet_set.size;
     velements_added = true;
 });
 
@@ -2103,9 +2111,10 @@ function avoidAnsweringBeforeWatchingThrough(){
 	<div class="col-md-2" sytle="float: right"><div class="loader" width="30%"></div></div>
 	<div class="col-md-3" sytle="text-align: left;"> <h1>Loading</h1>
 		<p>Loading the videos and checking your hardware. </p>
-		<p><span id ="remaining_videos">0</span> remains.</p>
-		<p><small>It might take up to a minute. In case it takes longer, refresh the page.</small></p></div>
-	<div class="col-md-3"></div>
+                <p><span id ="remaining_videos">0</span> remains.</p>
+                <p>Progress: <span id="loading_percent">0%</span></p>
+                <p><small>It might take up to a minute. In case it takes longer, refresh the page.</small></p></div>
+        <div class="col-md-3"></div>
 </div>
 
 <!-- Instructions -->

--- a/src/template/ACR_template.html
+++ b/src/template/ACR_template.html
@@ -942,16 +942,22 @@ function hardware_test(){
 		return;
 	}
 	if (!startScreenRefreshRateMeasures){
-		if (videos_not_loaded_yet_set.size == 0){
-			record_video_loading_time();
-			getScreenRefreshRate(function(fps){check_screen_refresh_rate(fps);});
-			startScreenRefreshRateMeasures = true;
+                if (videos_not_loaded_yet_set.size == 0){
+                        $("#loading_percent").html("100%");
+                        record_video_loading_time();
+                        getScreenRefreshRate(function(fps){check_screen_refresh_rate(fps);});
+                        startScreenRefreshRateMeasures = true;
 
 		}else{
 
-			$("#remaining_videos").html(videos_not_loaded_yet_set.size);
-			window.setTimeout(hardware_test, 200);
-			return;
+                        $("#remaining_videos").html(videos_not_loaded_yet_set.size);
+                        if(total_videos_count > 0){
+                                let loaded = total_videos_count - videos_not_loaded_yet_set.size;
+                                let percent = Math.round(100 * loaded / total_videos_count);
+                                $("#loading_percent").html(percent + "%");
+                        }
+                        window.setTimeout(hardware_test, 200);
+                        return;
 		}
 	}
 	if(refresh_rate_passed === null) {
@@ -983,6 +989,7 @@ function hardware_test(){
 //just tmp for test
 var video_size_MB = 0;
 var page_loading_timer =null;
+var total_videos_count = 0;
 
 /**
 	Called when downloading of all videos took too long, show a message and block the hit.
@@ -2321,6 +2328,7 @@ $(function() {
         recordError("on loading video clips",e.target.src, true);
         //$("#error_loading_files").show();
     });
+    total_videos_count = videos_not_loaded_yet_set.size;
     velements_added = true;
 });
 
@@ -2453,9 +2461,10 @@ function avoidAnsweringBeforeWatchingThrough(){
 	<div class="col-md-3" sytle="text-align: left;"> <h1>Loading</h1>
 		<p style="color:red">Do NOT open multiple pages of this task.</p>
 		<p>Loading the videos and checking your hardware. </p>
-		<p><span id ="remaining_videos">0</span> remains.</p>
-		<p><small>It might take up to a minute. In case it takes longer, refresh the page.</small></p></div>
-	<div class="col-md-3"></div>
+                <p><span id ="remaining_videos">0</span> remains.</p>
+                <p>Progress: <span id="loading_percent">0%</span></p>
+                <p><small>It might take up to a minute. In case it takes longer, refresh the page.</small></p></div>
+        <div class="col-md-3"></div>
 </div>
 
 <!-- Instructions -->

--- a/src/template/DCR_template.html
+++ b/src/template/DCR_template.html
@@ -1026,16 +1026,22 @@ function hardware_test(){
 		return;
 	}
 	if (!startScreenRefreshRateMeasures){
-		if (videos_not_loaded_yet_set.size == 0){
-			record_video_loading_time();
-			getScreenRefreshRate(function(fps){check_screen_refresh_rate(fps);});
-			startScreenRefreshRateMeasures = true;
+                if (videos_not_loaded_yet_set.size == 0){
+                        $("#loading_percent").html("100%");
+                        record_video_loading_time();
+                        getScreenRefreshRate(function(fps){check_screen_refresh_rate(fps);});
+                        startScreenRefreshRateMeasures = true;
 
 		}else{
 
-			$("#remaining_videos").html(videos_not_loaded_yet_set.size);
-			window.setTimeout(hardware_test, 200);
-			return;
+                        $("#remaining_videos").html(videos_not_loaded_yet_set.size);
+                        if(total_videos_count > 0){
+                                let loaded = total_videos_count - videos_not_loaded_yet_set.size;
+                                let percent = Math.round(100 * loaded / total_videos_count);
+                                $("#loading_percent").html(percent + "%");
+                        }
+                        window.setTimeout(hardware_test, 200);
+                        return;
 		}
 	}
 	if(refresh_rate_passed === null) {
@@ -1068,6 +1074,7 @@ function hardware_test(){
 //just tmp for test
 var video_size_MB = 0;
 var page_loading_timer =null;
+var total_videos_count = 0;
 /**
 	Called when downloading of all videos took too long, show a message and block the hit.
 **/
@@ -2559,6 +2566,7 @@ $(function() {
         recordError("on loading video clips",e.target.src);
         //$("#error_loading_files").show();
     });
+    total_videos_count = videos_not_loaded_yet_set.size;
     velements_added = true;
 });
 
@@ -2700,9 +2708,10 @@ function avoidAnsweringBeforeWatchingThrough(){
 	<div class="col-md-3" sytle="text-align: left;"> <h1>Loading</h1>
 		<p style="color:red">Do NOT open multiple pages of this task.</p>
 		<p>Loading the videos and checking your hardware. </p>
-		<p><span id ="remaining_videos">0</span> remains.</p>
-		<p><small>It might take up to a minute. In case it takes longer, refresh the page.</small></p></div>
-	<div class="col-md-3"></div>
+                <p><span id ="remaining_videos">0</span> remains.</p>
+                <p>Progress: <span id="loading_percent">0%</span></p>
+                <p><small>It might take up to a minute. In case it takes longer, refresh the page.</small></p></div>
+        <div class="col-md-3"></div>
 </div>
 
 <!-- Instructions -->

--- a/src/template/avatar_template.html
+++ b/src/template/avatar_template.html
@@ -1139,16 +1139,22 @@ function hardware_test(){
 		return;
 	}
 	if (!startScreenRefreshRateMeasures){
-		if (videos_not_loaded_yet_set.size == 0){
-			record_video_loading_time();
-			getScreenRefreshRate(function(fps){check_screen_refresh_rate(fps);});
+                if (videos_not_loaded_yet_set.size == 0){
+                        $("#loading_percent").html("100%");
+                        record_video_loading_time();
+                        getScreenRefreshRate(function(fps){check_screen_refresh_rate(fps);});
 			startScreenRefreshRateMeasures = true;
 
 		}else{
 
-			$("#remaining_videos").html(videos_not_loaded_yet_set.size);
-			window.setTimeout(hardware_test, 200);
-			return;
+                $("#remaining_videos").html(videos_not_loaded_yet_set.size);
+                if(total_videos_count > 0){
+                        let loaded = total_videos_count - videos_not_loaded_yet_set.size;
+                        let percent = Math.round(100 * loaded / total_videos_count);
+                        $("#loading_percent").html(percent + "%");
+                }
+                window.setTimeout(hardware_test, 200);
+                return;
 		}
 	}
 	if(refresh_rate_passed === null) {
@@ -1180,6 +1186,7 @@ function hardware_test(){
 //just tmp for test
 var video_size_MB = 0;
 var page_loading_timer =null;
+var total_videos_count = 0;
 
 /**
 	Called when downloading of all videos took too long, show a message and block the hit.
@@ -2881,6 +2888,7 @@ $(function() {
         recordError("on loading video clips",e.target.src, true);
         //$("#error_loading_files").show();
     });
+    total_videos_count = videos_not_loaded_yet_set.size;
     velements_added = true;
 });
 
@@ -3015,9 +3023,10 @@ function avoidAnsweringBeforeWatchingThrough(){
 	<div class="col-md-3" sytle="text-align: left;"> <h1>Loading</h1>
 		<p style="color:red">Do NOT open multiple pages of this task.</p>
 		<p>Loading the videos and checking your hardware. </p>
-		<p><span id ="remaining_videos">0</span> remains.</p>
-		<p><small>It might take up to a minute. In case it takes longer, refresh the page.</small></p></div>
-	<div class="col-md-3"></div>
+                <p><span id ="remaining_videos">0</span> remains.</p>
+                <p>Progress: <span id="loading_percent">0%</span></p>
+                <p><small>It might take up to a minute. In case it takes longer, refresh the page.</small></p></div>
+        <div class="col-md-3"></div>
 </div>
 
 <!-- Instructions -->


### PR DESCRIPTION
## Summary
- show loading percentage during video downloads
- track total videos to compute progress
- update progress across templates

## Testing
- `python3 -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError in create_trapping_clips.py)*

------
https://chatgpt.com/codex/tasks/task_e_6840d60a31888328b9d11919c28a435d